### PR TITLE
chore: remove unused permissions from manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,6 @@
     "48": "icon48.png",
     "128": "icon128.png"
   },
-  "permissions": ["activeTab", "storage"],
   "content_scripts": [
     {
       "matches": ["https://*.whatap.io/*"],


### PR DESCRIPTION
Remove activeTab and storage permissions that are not being used.
The extension uses localStorage (web API) instead of chrome.storage,
and has no browser action requiring activeTab.